### PR TITLE
replace "a"

### DIFF
--- a/po/common/ru.po
+++ b/po/common/ru.po
@@ -2557,7 +2557,7 @@ msgctxt "warning_3rd_party_content"
 msgid "Information and data must come from the product package and label (and not from other sites or the manufacturer's site), and you must have taken the pictures yourself.<br/>\n"
 "→ <a href=\"\">Why it matters</a>"
 msgstr "Информация и данные должны поступать  с упаковки товара и этикеток (а не с других сайтов или сайта производителя), а фотографии должны быть сняты вами.<br/>\n"
-"→ <а href=\"\">Почему это важно</а>"
+"→ <a href=\"\">Почему это важно</a>"
 
 msgctxt "website"
 msgid "Site or blog address"


### PR DESCRIPTION
**Description:** Apparently the "a" was a different character, so that the link wasn't closed correctly.
**Related issues and discussion:** Fixes openfoodfacts/openfoodfacts-server#1237
